### PR TITLE
chore: remove unneeded env variables and command processing

### DIFF
--- a/config-default.toml
+++ b/config-default.toml
@@ -11,9 +11,6 @@ log_level = "INFO"
 discord_log_level = "INFO"
 
 [bot]
-# The prefixes Metricity respond to.
-command_prefix = ["m!"]
-
 # The token Metricity will use to authenticate with Discord.
 token = { env = "BOT_TOKEN" }
 
@@ -39,9 +36,6 @@ staff_categories = [
 ignore_categories = [
     714494672835444826
 ]
-
-# Respond to opt-in/opt-out commands in the following channel
-bot_commands_channel = 267659945086812160
 
 [database]
 # Postgres!

--- a/metricity/bot.py
+++ b/metricity/bot.py
@@ -37,7 +37,8 @@ intents = Intents(
 
 
 bot = Bot(
-    command_prefix=BotConfig.command_prefix,
+    command_prefix="",
+    help_command=None,
     intents=intents,
     max_messages=None,
     activity=Game(f"Metricity {__version__}")
@@ -288,9 +289,6 @@ async def on_member_update(before: Member, member: Member) -> None:
 async def on_message(message: DiscordMessage) -> None:
     """Add a message to the table when one is sent providing the author has accepted."""
     await db_ready.wait()
-
-    if message.channel.id == BotConfig.bot_commands_channel:
-        await bot.process_commands(message)
 
     if not message.guild:
         return

--- a/metricity/config.py
+++ b/metricity/config.py
@@ -2,7 +2,7 @@
 import logging
 from os import environ
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 import toml
 from deepmerge import Merger

--- a/metricity/config.py
+++ b/metricity/config.py
@@ -109,7 +109,6 @@ class BotConfig(metaclass=ConfigSection):
 
     section = "bot"
 
-    command_prefix: Union[List[str], str]
     token: str
 
     guild_id: int
@@ -117,8 +116,6 @@ class BotConfig(metaclass=ConfigSection):
 
     staff_categories: List[int]
     ignore_categories: List[int]
-
-    bot_commands_channel: int
 
 
 class DatabaseConfig(metaclass=ConfigSection):


### PR DESCRIPTION
Since the option to opt-in or out of metric collection was removed there are no longer any commands in Metricity, this means the following changes can be made (and have been made in this PR):
- removing `bot_commands_channel` config option, it's now redundant
- removing `command_prefix` config option, there are no commands, prefix now set to `""`
- adding `help_command=None` to the constructor, else you just get this: