### PR TITLE
Prevent error on uncategorized channel.

### DIFF
--- a/metricity/bot.py
+++ b/metricity/bot.py
@@ -78,10 +78,9 @@ async def sync_channels(guild: Guild) -> None:
                     name=channel.name,
                     category_id=str(channel.category.id) if channel.category else None,
                     is_staff=(
-                        True
-                        if channel.category.id in BotConfig.staff_categories
-                        else False
-                    )
+                        channel.category
+                        and channel.category.id in BotConfig.staff_categories
+                    ),
                 ).apply()
             else:
                 await Channel.create(
@@ -89,10 +88,9 @@ async def sync_channels(guild: Guild) -> None:
                     name=channel.name,
                     category_id=str(channel.category.id) if channel.category else None,
                     is_staff=(
-                        True
-                        if channel.category.id in BotConfig.staff_categories
-                        else False
-                    )
+                        channel.category
+                        and channel.category.id in BotConfig.staff_categories
+                    ),
                 )
 
     channel_sync_in_progress.set()


### PR DESCRIPTION
If the channel is not part of a category, `channel.category` will be
`None`, and the check would fail with an `AttributeError`.