### PR TITLE
Metricity creates own database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN poetry config virtualenvs.create false && poetry install
 
 COPY . /metricity
 
-CMD ["sh", "-c", "alembic upgrade head && poetry run start"]
+CMD ["bash", "entry_point.sh"]

--- a/create_metricity_db.py
+++ b/create_metricity_db.py
@@ -1,0 +1,46 @@
+"""Ensures the metricity db exists before running migrations."""
+import os
+from urllib.parse import SplitResult, urlsplit
+
+import psycopg2
+from psycopg2 import sql
+from psycopg2.extensions import ISOLATION_LEVEL_AUTOCOMMIT
+
+
+def parse_db_url(db_url: str) -> SplitResult:
+    """Validate and split the given databse url."""
+    db_url_parts = urlsplit(db_url)
+    if not all((
+        db_url_parts.hostname,
+        db_url_parts.username,
+        db_url_parts.password
+    )):
+        raise ValueError(
+            "The given db_url is not a valid PostgreSQL database URL."
+        )
+    return db_url_parts
+
+
+if __name__ == "__main__":
+    database_parts = parse_db_url(os.environ["DATABASE_URI"])
+
+    conn = psycopg2.connect(
+        host=database_parts.hostname,
+        port=database_parts.port,
+        user=database_parts.username,
+        password=database_parts.password
+    )
+
+    db_name = database_parts.path[1:] or "metricity"
+
+    # Required to create a database in a .execute() call
+    conn.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
+    with conn.cursor() as cursor:
+        cursor.execute("SELECT 1 FROM pg_catalog.pg_database WHERE datname = %s", (db_name,))
+        exists = cursor.fetchone()
+        if not exists:
+            print("Creating metricity database.")
+            cursor.execute(
+                sql.SQL("CREATE DATABASE {dbname}").format(dbname=sql.Identifier(db_name))
+            )
+    conn.close()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3.8"
+
+x-logging: &logging
+  logging:
+    driver: "json-file"
+    options:
+      max-file: "5"
+      max-size: "10m"
+
+x-restart-policy: &restart_policy
+  restart: "no"
+
+services:
+  postgres:
+    << : *logging
+    << : *restart_policy
+    image: postgres:13-alpine
+    environment:
+      POSTGRES_DB: pysite
+      POSTGRES_PASSWORD: pysite
+      POSTGRES_USER: pysite
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U pysite"]
+      interval: 2s
+      timeout: 1s
+      retries: 5
+
+  metricity:
+    << : *logging
+    << : *restart_policy
+    depends_on: 
+      postgres:
+        condition: service_healthy
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./logs:/metricity/logs
+      - .:/metricity:ro
+    env_file:
+      - .env
+    environment:
+      DATABASE_URI: postgres://pysite:pysite@postgres

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -4,6 +4,6 @@ python create_metricity_db.py
 alembic upgrade head
 
 shopt -s nocasematch
-if [ "$skip_metricity" != "true" ]; then
+if [ "$SKIP_METRICITY" != "true" ]; then
     poetry run start
 fi

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -1,6 +1,9 @@
 set -e
+
 python create_metricity_db.py
 alembic upgrade head
-if [ -z "$skip_metricity" ]; then
+
+shopt -s nocasematch
+if [ "$skip_metricity" != "true" ]; then
     poetry run start
 fi

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -1,0 +1,6 @@
+set -e
+python create_metricity_db.py
+alembic upgrade head
+if [ -z "$skip_metricity" ]; then
+    poetry run start
+fi


### PR DESCRIPTION
This ensures that metricity creates it's own database before trying to run migrations.

It uses the given connection string, defaulting to a database name of metricity if there isn't one specified.