### PR TITLE
Various fixes related to thread support

### DIFF
--- a/metricity/bot.py
+++ b/metricity/bot.py
@@ -120,6 +120,9 @@ async def sync_channels(guild: Guild) -> None:
         if thread.parent and thread.parent.category:
             if thread.parent.category.id in BotConfig.ignore_categories:
                 continue
+        else:
+            # This is a forum channel, not currently supported by Discord.py. Ignore it.
+            continue
 
         if db_thread := await Thread.get(str(thread.id)):
             await db_thread.update(
@@ -382,11 +385,12 @@ async def on_message(message: DiscordMessage) -> None:
     }
 
     if isinstance(message.channel, ThreadChannel):
+        if not message.channel.parent:
+            # This is a forum channel, not currently supported by Discord.py. Ignore it.
+            return
         thread = message.channel
         args["channel_id"] = str(thread.parent_id)
         args["thread_id"] = str(thread.id)
-        if not await Thread.get(str(thread.id)):
-            await insert_thread(thread)
 
     await Message.create(**args)
 

--- a/metricity/bot.py
+++ b/metricity/bot.py
@@ -185,6 +185,23 @@ async def on_guild_channel_update(_before: Messageable, channel: Messageable) ->
 
 
 @bot.event
+async def on_thread_join(thread: ThreadChannel) -> None:
+    """
+    Sync channels when thread join is triggered.
+
+    Unlike what the name suggested, this is also triggered when:
+       - A thread is created.
+       - An un-cached thread is un-archived.
+    """
+    await db_ready.wait()
+
+    if thread.guild.id != BotConfig.guild_id:
+        return
+
+    await sync_channels(thread.guild)
+
+
+@bot.event
 async def on_thread_update(_before: Messageable, thread: Messageable) -> None:
     """Sync the channels when one is updated."""
     await db_ready.wait()
@@ -206,6 +223,9 @@ async def on_guild_available(guild: Guild) -> None:
         return log.info("Guild was not the configured guild, discarding event")
 
     await sync_channels(guild)
+
+    log.info("Beginning thread archive state synchronisation process")
+    await sync_thread_archive_state(guild)
 
     log.info("Beginning user synchronisation process")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "metricity"
-version = "1.3.0"
+version = "1.3.1"
 description = "Advanced metric collection for the Python Discord server"
 authors = ["Joe Banks <joseph@josephbanks.me>"]
 license = "MIT"


### PR DESCRIPTION
This fixes a few bugs around threads namely:

1. Ignore threads within forum channels. These aren't supported by d.py so we want to avoid tracebacks.
2. Listen for thread create and unarchive events explicitly
     - Discord.py only firsts thread_update events for threads in the cache, this isn't the case for threads being created, and threads being unarchived, so there events were previously being missed from the channel sync.
3. Only sync archive status on startup
    - Since we now sync archive flags during bot runtime, there is no need to sync this every time we sync threads.