### PR TITLE
Fix Poetry 1.2 Support

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Install Python Dependencies
-      uses: HassanAbouelela/actions/setup-python@setup-python_v1.1.0
+      uses: HassanAbouelela/actions/setup-python@setup-python_v1.3.1
       with:
         # Set dev=true to install flake8 extensions, which are dev dependencies
         dev: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,12 @@
-FROM python:3.9.5-slim
+FROM --platform=linux/amd64 ghcr.io/chrislovering/python-poetry-base:3.9-slim
 
-ENV PYTHONFAULTHANDLER=1 \
-    PYTHONUNBUFFERED=1 \
-    PYTHONHASHSEED=random \
-    PIP_NO_CACHE_DIR=off \
-    PIP_DISABLE_PIP_VERSION_CHECK=on \
-    PIP_DEFAULT_TIMEOUT=100
+ENV PYTHONHASHSEED=random
 
-RUN pip install poetry
-
+# Install Dependencies
 WORKDIR /metricity
-COPY poetry.lock pyproject.toml /metricity/
+COPY poetry.lock pyproject.toml ./
+RUN poetry install
 
-RUN poetry config virtualenvs.create false && poetry install
 
 COPY . /metricity
-
 CMD ["bash", "entry_point.sh"]

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -1,7 +1,7 @@
 set -e
 
-python create_metricity_db.py
-alembic upgrade head
+poetry run python create_metricity_db.py
+poetry run alembic upgrade head
 
 if [ -e /tmp/bot/metricity-config.toml ]; then
     echo "Detected metricity running in bot context, copying config." 


### PR DESCRIPTION
Poetry 1.2 introduced a regression which broke pip `--user` installs. These types of install were the main way we did installations in docker and CI, as they made it much more convenient to control the location, availability, and caching of packages.

Poetry's team does not recognize this as a supported use case, so major changes were required to get everything working again. Most of the changes were consolidated into chrislovering/python-poetry-base for docker, and HassanAbouelela/setup-python for CI.

This is part of a collection of PRs made to python-discord projects.