### PR TITLE
Allow changing the config file location with CONFIG_LOCATION

### DIFF
--- a/metricity/config.py
+++ b/metricity/config.py
@@ -33,10 +33,11 @@ def get_section(section: str) -> dict[str, Any]:
 
     # Load user configuration
     user_config = {}
+    user_config_location = Path(environ.get("CONFIG_LOCATION", "./config.toml"))
 
-    if Path("config.toml").exists():
-        with open("config.toml", "r") as default_config_file:
-            user_config = toml.load(default_config_file)
+    if user_config_location.exists():
+        with open(user_config_location, "r") as user_config_file:
+            user_config = toml.load(user_config_file)
 
     # Merge the configuration
     merger = Merger(


### PR DESCRIPTION
Currently, it is mandatory for you to put the config file in the same folder as the code. This raises issues in environments such as Kubernetes. This commit allows the user to use `CONFIG_LOCATION` to change the location of that file, while keeping the current behavior as default.