### PR TITLE
Also tag GHCR images with major version number

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -42,6 +42,7 @@ jobs:
             type=raw,value=${{ inputs.sha-tag }}
             type=raw,value=latest
             type=semver,pattern=v{{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern=v{{major}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push
         uses: docker/build-push-action@v4


### PR DESCRIPTION
This will allow users to pin to a specific major version, allowing for minor updates but no breaking changes