### PR TITLE
Add column for a channel that has been deleted

### DIFF
--- a/alembic/versions/c09a64cac3cb_add_deleted_column_to_channel_model.py
+++ b/alembic/versions/c09a64cac3cb_add_deleted_column_to_channel_model.py
@@ -1,0 +1,28 @@
+"""
+Add deleted column to channel model.
+
+Revision ID: c09a64cac3cb
+Revises: 03655ce2097b
+Create Date: 2024-04-07 22:58:53.186355
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c09a64cac3cb"
+down_revision = "03655ce2097b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply the current migration."""
+    op.add_column("channels", sa.Column("deleted", sa.Boolean(), nullable=False, server_default="False", default=False))
+
+
+def downgrade() -> None:
+    """Revert the current migration."""
+    op.drop_column("channels", "deleted")

--- a/metricity/models.py
+++ b/metricity/models.py
@@ -30,6 +30,7 @@ class Channel(Base):
     name: Mapped[str]
     category_id: Mapped[str | None] = mapped_column(ForeignKey("categories.id", ondelete="CASCADE"))
     is_staff: Mapped[bool]
+    deleted: Mapped[bool] = mapped_column(default=False)
 
 
 class Thread(Base):


### PR DESCRIPTION
- Add a database column and migration for tracking if a channel has been deleted
- Update the channel syncer to set the deleted flag to True for all channels not in `guild.channels`, on channel create, delete and bot start-up.