### PR TITLE
Improve user in-guild sync process

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,21 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      docker-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      ci-dependencies:
+        patterns:
+          - "*"

--- a/metricity/exts/event_listeners/startup_sync.py
+++ b/metricity/exts/event_listeners/startup_sync.py
@@ -7,6 +7,7 @@ from discord.ext import commands
 from pydis_core.utils import logging, scheduling
 from sqlalchemy import column, select
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import load_only
 
 from metricity import models
 from metricity.bot import Bot
@@ -95,7 +96,9 @@ class StartupSyncer(commands.Cog):
         users_updated = 0
         guild_member_ids = {str(member.id) for member in guild.members}
         async with async_session() as sess:
-            res = await sess.execute(select(models.User).filter_by(in_guild=True))
+
+            stmt = select(models.User).filter_by(in_guild=True).options(load_only(models.User.id))
+            res = await sess.execute(stmt)
             in_guild_users = res.scalars()
             for user in in_guild_users:
                 if user.id not in guild_member_ids:


### PR DESCRIPTION
Closes #157

Previously we set all users in_guild to False, and relied on users being set back to in_guild when iterating through guild.members

However, this caused two problems
1. For a short window a users in_guild status was incorrect
2. It required an update for all users in_guild to be sent to postgres to update in_guild back to True.

This diff changes that, so instead only users who are not found in the guild have in_guild set to False.

The bottleneck for this process currently is the number of users that need to be committed back to the database.
Testing locally, with 380k users off guild, the perf logging outputs: `in_guild sync: total time 19.140096s, query 3.486625s, processing 0.540042s, commit 15.113428s`. The commit timing isn't reliabale, as it is dependent on how long it takes for control to be passed back after awaiting